### PR TITLE
Make block icons more specific to the blocks

### DIFF
--- a/blocks/activity-list/index.js
+++ b/blocks/activity-list/index.js
@@ -19,7 +19,7 @@ export default registerBlockType(
 	{
 		title: __( 'Activity list' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'tickets',
 		keywords: [
 			__( 'Browse activities' ),
 			__( 'Travel' )

--- a/blocks/discover/index.js
+++ b/blocks/discover/index.js
@@ -17,7 +17,7 @@ export default registerBlockType(
 	{
 		title: __( 'Discover block' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'palmtree',
 		keywords: [
 			__( 'Adventures' ),
 			__( 'Travel' )

--- a/blocks/featured/index.js
+++ b/blocks/featured/index.js
@@ -16,7 +16,7 @@ export default registerBlockType(
 	{
 		title: __( 'Featured Destinations' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'location-alt',
 		keywords: [
 			__( 'Featured destinations' ),
 			__( 'Adventures' ),

--- a/blocks/hero/index.js
+++ b/blocks/hero/index.js
@@ -19,7 +19,7 @@ export default registerBlockType(
 		title: __( 'Hero block' ),
 		description: __( 'Hero block of the Travel theme. Includes main heading, subheading, and search with datepicker.' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'slides',
 		keywords: [
 			__( 'Main header' ),
 			__( 'Heading' ),

--- a/blocks/popular/index.js
+++ b/blocks/popular/index.js
@@ -15,7 +15,7 @@ export default registerBlockType(
 	{
 		title: __( 'Popular Adventures' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'universal-access',
 		keywords: [
 			__( 'Top rated' ),
 			__( 'Best' ),

--- a/blocks/search/index.js
+++ b/blocks/search/index.js
@@ -18,7 +18,7 @@ export default registerBlockType(
 	{
 		title: __( 'Search' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'search',
 		keywords: [
 			__( 'Adventure' ),
 			__( 'Travel' )

--- a/blocks/travel-angles/index.js
+++ b/blocks/travel-angles/index.js
@@ -12,7 +12,7 @@ export default registerBlockType(
 	{
 		title: __( 'Travel Angles' ),
 		category: 'common',
-		icon: 'wordpress-alt',
+		icon: 'format-image',
 		keywords: [
 			__( 'Design' )
 		],


### PR DESCRIPTION
**Request For Code Review**

Hi @miina,
Could you please review this pull request, which changes the block [icons](https://developer.wordpress.org/resource/dashicons/)? 

<img width="428" alt="new-block-icons" src="https://user-images.githubusercontent.com/4063887/38964144-ddaba424-433a-11e8-8959-7fefa84df6cb.png">
