### PR TITLE
Address 'Hero' and 'Discover' block mobile styling.

### DIFF
--- a/blocks/discover/index.js
+++ b/blocks/discover/index.js
@@ -34,11 +34,11 @@ export default registerBlockType(
 
 			const content = 0 === posts.data.length ?
 				(
-					<div className='travel-discover-panel travel-shadow-hover px3 py2 ml1 mr3 myn3 xs-hide sm-hide'>
+					<div className='travel-discover-panel travel-shadow-hover px3 py2 ml1 mr3 myn3'>
 						<div>{ __( 'No posts found, add some to use the block.' ) }</div>
 					</div> ) :
 				(
-					<div className='travel-discover-panel travel-shadow-hover px3 py2 ml1 myn3 xs-hide sm-hide'>
+					<div className='travel-discover-panel travel-shadow-hover px3 py2 ml1 myn3'>
 						<div className='bold h2 line-height-2 my1'>{ posts.data[0].title.rendered }</div>
 						<p className='travel-discover-panel-subheading h3 my1 line-height-2'>
 							<RawHTML key='html'>{ decodeEntities( posts.data[0].excerpt.rendered ) }</RawHTML>
@@ -50,7 +50,7 @@ export default registerBlockType(
 				);
 
 			return (
-				<section className='travel-discover py4 mb3 relative xs-hide sm-hide'>
+				<section className='travel-discover py4 mb3 relative'>
 					<div className='max-width-3 mx-auto'>
 						<div className='flex justify-between items-center'>
 							<header>

--- a/blocks/hero/index.js
+++ b/blocks/hero/index.js
@@ -127,7 +127,7 @@ export default registerBlockType(
 
 			return (
 				<section className='travel-hero relative'>
-					<div className='travel-hero-content max-width-3 mx-auto absolute top-0 left-0 right-0 flex self-end items-center'>
+					<div className='travel-hero-content max-width-3 mx-auto relative top-0 left-0 right-0 flex self-end items-center'>
 						<div className='travel-hero-content-inner relative px1 md-px2 flex-auto self-end'>
 							<header>
 								<h1 className='travel-hero-heading mb2 line-height-1'>{ attributes.heading }</h1>

--- a/includes/class-amp-travel-blocks.php
+++ b/includes/class-amp-travel-blocks.php
@@ -453,14 +453,14 @@ class AMP_Travel_Blocks {
 			$excerpt = get_the_excerpt( $discover_post['ID'] );
 		}
 
-		$output = '<section class="travel-discover py4 mb3 relative xs-hide sm-hide">
+		$output = '<section class="travel-discover py4 mb3 relative">
 				<div class="max-width-3 mx-auto px1 md-px2">
 					<div class="flex justify-between items-center">
 						<header>
 							<h2 class="travel-discover-heading bold line-height-2 xs-hide sm-hide">' . esc_html( $heading ) . '</h2>
 							<div class="travel-discover-subheading h2 xs-hide sm-hide">' . esc_html( $subheading ) . '</div>
 						</header>
-						<div class="travel-discover-panel travel-shadow-hover px3 py2 ml1 mr3 myn3 xs-hide sm-hide">
+						<div class="travel-discover-panel travel-shadow-hover px3 py2 ml1 mr3 myn3">
 							<div class="bold h2 line-height-2 my1">' . esc_html( $title ) . '</div>
 							<p class="travel-discover-panel-subheading h3 my1 line-height-2">
 								' . esc_html( $excerpt ) . '


### PR DESCRIPTION
**Request For Review**

Hi @miina,
Could you please review this PR? The 'Hero' and 'Discover' blocks don't appear on the mobile [homepage](http://dev-amp-start-travel.pantheonsite.io/):

<img width="685" alt="hero-discover" src="https://user-images.githubusercontent.com/4063887/38966084-f4c7cfce-4345-11e8-985e-ea0e3f026ad6.png">

Per [our design](https://www.figma.com/file/L14jTE7iNGOE7DH57Ro7ncyu/Travel-Theme?node-id=1%3A9), both blocks should display on mobile.

I'm not sure if this is the right solution. Especially changing the class in the 'Hero' to 'relative.' But we're also going to combine the 'Hero' with the 'Travel Angles' block, so it might not be crucial to get this right.

Please rebuild the `editor-blocks.js` file locally, and you'll probably have to recreate these blocks to see the changes.

Closes #53.