### PR TITLE
[Gutenberg] Add fields for editing dynamic blocks' settings

### DIFF
--- a/blocks/activity-list/index.js
+++ b/blocks/activity-list/index.js
@@ -54,7 +54,7 @@ export default registerBlockType(
 						</PanelBody>
 					</InspectorControls>
 				),
-				<section className='travel-activities pb4 pt3 relative'>
+				<section key='activities' className='travel-activities pb4 pt3 relative'>
 					<div className='max-width-3 mx-auto px1 md-px2'>
 						<h3 className='bold h1 line-height-2'>{ heading }</h3>
 					</div>

--- a/blocks/activity-list/index.js
+++ b/blocks/activity-list/index.js
@@ -6,8 +6,8 @@
  * Internal block libraries.
  */
 const { __ } = wp.i18n;
-const { registerBlockType, RichText } = wp.blocks;
-const { Placeholder, withAPIData } = wp.components;
+const { registerBlockType, InspectorControls } = wp.blocks;
+const { Placeholder, withAPIData, TextControl, PanelBody } = wp.components;
 const { RawHTML } = wp.element;
 const { decodeEntities } = wp.utils;
 
@@ -29,7 +29,7 @@ export default registerBlockType(
 			return {
 				activityResults: '/wp/v2/activities'
 			};
-		} )( ( { activityResults } ) => {
+		} )( ( { activityResults, isSelected, setAttributes, attributes: { heading } } ) => {
 			const hasActivities = Array.isArray( activityResults.data ) && activityResults.data.length;
 			if ( ! hasActivities ) {
 				return (
@@ -42,10 +42,21 @@ export default registerBlockType(
 
 			const activities = activityResults.data;
 
-			return (
+			return [
+				isSelected && (
+					<InspectorControls key='inspector'>
+						<PanelBody title={ __( 'Activity List settings' ) }>
+							<TextControl
+								label={ __( 'Activity List Header' ) }
+								value={ heading }
+								onChange={ ( value ) => setAttributes( { heading: value } ) }
+							/>
+						</PanelBody>
+					</InspectorControls>
+				),
 				<section className='travel-activities pb4 pt3 relative'>
 					<div className='max-width-3 mx-auto px1 md-px2'>
-						<h3 className='bold h1 line-height-2'>{ __( 'Browse by activity' ) }</h3>
+						<h3 className='bold h1 line-height-2'>{ heading }</h3>
 					</div>
 					<div className='overflow-scroll'>
 						<div className='travel-overflow-container'>
@@ -67,7 +78,7 @@ export default registerBlockType(
 						</div>
 					</div>
 				</section>
-			);
+			];
 		} ),
 		save() {
 

--- a/blocks/discover/index.js
+++ b/blocks/discover/index.js
@@ -4,8 +4,8 @@
  * Internal block libraries.
  */
 const { __ } = wp.i18n;
-const { registerBlockType, RichText } = wp.blocks;
-const { withAPIData } = wp.components;
+const { registerBlockType, InspectorControls } = wp.blocks;
+const { withAPIData, TextControl, PanelBody } = wp.components;
 const { RawHTML } = wp.element;
 const { decodeEntities }  = wp.utils;
 
@@ -27,7 +27,7 @@ export default registerBlockType(
 			return {
 				posts: '/wp/v2/posts?per_page=1'
 			};
-		} )( ( { posts } ) => {
+		} )( ( { posts, isSelected, setAttributes, attributes: { heading, subheading } } ) => {
 			if ( ! posts.data ) {
 				return __( 'Loading...' );
 			}
@@ -49,19 +49,35 @@ export default registerBlockType(
 					</div>
 				);
 
-			return (
+			return [
+				isSelected && (
+					<InspectorControls key='inspector'>
+						<PanelBody title={ __( 'Discover block settings' ) }>
+							<TextControl
+								label={ __( 'Discover Header' ) }
+								value={ heading }
+								onChange={ ( value ) => setAttributes( { heading: value } ) }
+							/>
+							<TextControl
+								label={ __( 'Discover Sub-heading' ) }
+								value={ subheading }
+								onChange={ ( value ) => setAttributes( { subheading: value } ) }
+							/>
+						</PanelBody>
+					</InspectorControls>
+				),
 				<section className='travel-discover py4 mb3 relative'>
 					<div className='max-width-3 mx-auto'>
 						<div className='flex justify-between items-center'>
 							<header>
-								<h2 className='travel-discover-heading bold line-height-2 xs-hide sm-hide'>{ __( 'Discover Adventures' ) }</h2>
-								<div className='travel-discover-subheading h2 xs-hide sm-hide'>{ __( 'Get inspired and find your next big trip' ) }</div>
+								<h2 className='travel-discover-heading bold line-height-2 xs-hide sm-hide'>{ heading }</h2>
+								<div className='travel-discover-subheading h2 xs-hide sm-hide'>{ subheading }</div>
 							</header>
 							{ content }
 						</div>
 					</div>
 				</section>
-			);
+			];
 		} ),
 		save() {
 

--- a/blocks/discover/index.js
+++ b/blocks/discover/index.js
@@ -66,7 +66,7 @@ export default registerBlockType(
 						</PanelBody>
 					</InspectorControls>
 				),
-				<section className='travel-discover py4 mb3 relative'>
+				<section key='discover' className='travel-discover py4 mb3 relative'>
 					<div className='max-width-3 mx-auto'>
 						<div className='flex justify-between items-center'>
 							<header>

--- a/blocks/featured/index.js
+++ b/blocks/featured/index.js
@@ -5,8 +5,8 @@
  * Internal block libraries.
  */
 const { __ } = wp.i18n;
-const { registerBlockType } = wp.blocks;
-const { Placeholder, withAPIData } = wp.components;
+const { registerBlockType, InspectorControls } = wp.blocks;
+const { Placeholder, withAPIData, TextControl, PanelBody } = wp.components;
 
 /**
  * Register block.
@@ -23,24 +23,16 @@ export default registerBlockType(
 			__( 'Travel' )
 		],
 
-		attributes: {
-			heading: {
-				selector: '.travel-featured-heading',
-				source: 'children',
-				type: 'array'
-			}
-		},
-
 		edit: withAPIData( () => {
 			return {
 				featuredLocations: '/wp/v2/locations?per_page=6&meta_value=1&meta_key=amp_travel_featured'
 			};
-		} )( ( { featuredLocations } ) => { // eslint-disable-line
+		} )( ( { featuredLocations, isSelected, setAttributes, attributes: { heading } } ) => { // eslint-disable-line
 			const hasLocations = Array.isArray( featuredLocations.data ) && 6 <= featuredLocations.data.length;
 			if ( ! hasLocations ) {
 				return (
-					<Placeholder key="placeholder"
-								icon="admin-post"
+					<Placeholder key='placeholder'
+								icon='admin-post'
 								label={ __( 'Locations' ) }
 					>
 						{ __( 'Not enough featured locations found. Please add at least six "Locations" terms, select an image, and check "Featured destination."' ) }
@@ -76,10 +68,21 @@ export default registerBlockType(
 				}
 			];
 
-			return (
+			return [
+				isSelected && (
+					<InspectorControls key='inspector'>
+						<PanelBody title={ __( 'Featured Destinations settings' ) }>
+							<TextControl
+								label={ __( 'Featured Destinations Header' ) }
+								value={ heading }
+								onChange={ ( value ) => setAttributes( { heading: value } ) } // eslint-disable-line
+							/>
+						</PanelBody>
+					</InspectorControls>
+				),
 				<section className='travel-featured pt3 relative clearfix'>
 					<header className='max-width-2 mx-auto px1 md-px2 relative'>
-						<h3 className='travel-featured-heading h1 bold line-height-2 mb2 center'>{ __( 'Featured Destinations' ) }</h3>
+						<h3 className='travel-featured-heading h1 bold line-height-2 mb2 center'>{ heading }</h3>
 					</header>
 					<div className='max-width-3 mx-auto relative'>
 						<div className='travel-featured-grid flex flex-wrap items-stretch'>
@@ -136,7 +139,7 @@ export default registerBlockType(
 						</div>
 					</div>
 				</section>
-			);
+			];
 		} ), // eslint-disable-line
 		save() {
 

--- a/blocks/featured/index.js
+++ b/blocks/featured/index.js
@@ -80,7 +80,7 @@ export default registerBlockType(
 						</PanelBody>
 					</InspectorControls>
 				),
-				<section className='travel-featured pt3 relative clearfix'>
+				<section key='featured' className='travel-featured pt3 relative clearfix'>
 					<header className='max-width-2 mx-auto px1 md-px2 relative'>
 						<h3 className='travel-featured-heading h1 bold line-height-2 mb2 center'>{ heading }</h3>
 					</header>

--- a/blocks/popular/index.js
+++ b/blocks/popular/index.js
@@ -4,8 +4,8 @@
  * Internal block libraries.
  */
 const { __ } = wp.i18n;
-const { registerBlockType, RichText } = wp.blocks;
-const { Placeholder, withAPIData } = wp.components;
+const { registerBlockType, InspectorControls } = wp.blocks;
+const { Placeholder, withAPIData, TextControl, PanelBody } = wp.components;
 
 /**
  * Register block.
@@ -26,7 +26,7 @@ export default registerBlockType(
 			return {
 				popularPosts: '/wp/v2/adventures?per_page=3&orderby=meta_value_num&meta_key=amp_travel_rating&_embed'
 			};
-		} )( ( { popularPosts } ) => { // eslint-disable-line
+		} )( ( { popularPosts, isSelected, setAttributes, attributes: { heading } } ) => { // eslint-disable-line
 			const popularPostsCount = 3;
 			const hasAdventures = Array.isArray( popularPosts.data ) && popularPosts.data.length;
 			if ( ! hasAdventures || popularPostsCount !== popularPosts.data.length ) {
@@ -44,10 +44,21 @@ export default registerBlockType(
 				'travel-popular-tilt-left'
 			];
 
-			return (
-				<section className='travel-popular pb4 pt3 relative'>
+			return [
+				isSelected && (
+					<InspectorControls key='inspector'>
+						<PanelBody title={ __( 'Popular block settings' ) }>
+							<TextControl
+								label={ __( 'Popular Adventures Header' ) }
+								value={ heading }
+								onChange={ ( value ) => setAttributes( { heading: value } ) } // eslint-disable-line
+							/>
+						</PanelBody>
+					</InspectorControls>
+				),
+				<section key='popular' className='travel-popular pb4 pt3 relative'>
 					<header className='max-width-3 mx-auto px1 md-px2'>
-						<h3 className='h1 bold line-height-2'>{ __( 'Top Adventures' ) }</h3>
+						<h3 className='h1 bold line-height-2'>{ heading }</h3>
 					</header>
 					<div className='overflow-scroll'>
 						<div className='travel-overflow-container'>
@@ -87,7 +98,7 @@ export default registerBlockType(
 						</div>
 					</div>
 				</section>
-			);
+			];
 		}),
 		save() {
 


### PR DESCRIPTION
Adds fields for editing heading / subheading for the following blocks:
- Activity List;
- Discover;
- Featured Destinations;
- Popular;

Sample screenshot:
![screen shot 2018-04-19 at 4 59 19 pm](https://user-images.githubusercontent.com/3294597/38998637-acab77be-43f8-11e8-9e66-72356a077e6e.png)

Closes #51.