### PR TITLE
Apply a dynamic URL to the header icon on the homepage

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@ get_header();
 	<section class="relative z2">
 		<header class="travel-header absolute top-0 right-0 left-0">
 			<div class="px1 md-px2 py1 md-py2 flex justify-between items-center">
-				<a href="travel.amp" class="travel-icon-logo mx-auto inline-block circle">
+				<a href="<?php echo esc_url( home_url() ); ?>" class="travel-icon-logo mx-auto inline-block circle">
 					<svg class="travel-icon travel-icon-logo h2" viewbox="0 0 100 100"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-width="7.5"><circle cx="50" cy="50" r="45"></circle><path d="M20.395 83.158c-2.37-10.263-.79-18.553 4.737-24.87 8.29-9.472 17.763-1.183 26.052-9.472 8.29-8.29 2.37-18.948 10.658-26.053 5.526-4.737 12.237-6.316 20.132-4.737M39.084 95c-2.788-10.2-1.912-17.304 2.627-21.316 6.808-6.017 14.956-.68 24.088-9.623 9.13-8.94 3.062-17.133 10.255-23.534 4.795-4.267 10.282-5.668 16.46-4.203"></path></g></svg>        </a>
 			</div>
 		</header>


### PR DESCRIPTION
Hi @miina,
Could you please review this PR, which ensures the icon on the upper left of the homepage (index.php) always goes to the homepage?

The rest of the header 'homepage' links look good.

<img width="1032" alt="home-page-link" src="https://user-images.githubusercontent.com/4063887/39159078-4ac1e39c-4729-11e8-9231-2eb7aa9d2259.png">
