### PR TITLE
Hide AMP plugin validator notices for the screencast

### DIFF
--- a/assets/css/editor-blocks.css
+++ b/assets/css/editor-blocks.css
@@ -55,3 +55,8 @@ html{font-family:sans-serif;line-height:1.15;-ms-text-size-adjust:100%;-webkit-t
 .editor-block-list__layout {
     overflow: hidden;
 }
+
+/* Hide AMP plugin validator notices for the screencast */
+.notice-warning {
+    display: none;
+}


### PR DESCRIPTION
**Request For Review**

Hi @miina,
Could you please review this PR?

The editor for the home page shows a notice for the entire page:
>"Too much CSS is enqueued and so seemingly irrelevant rules have been removed."

This is a valid notice, but it'd be better to not have it in the screencast. And the 'tree shaking' seemingly removes the extra CSS.

Also, the hero block on the top has a notice from the `<amp-list>` not using https for its src.

This new style rule hides both notices. We can revert this later, as the plugin will probably have a way to ignore errors.

<img width="1434" alt="edit-errors" src="https://user-images.githubusercontent.com/4063887/39218429-4e9dd8d8-47ea-11e8-83fc-22c99b4c7dda.png">
