### PR TITLE
remove amp-list from hero block

### DIFF
--- a/blocks/hero/index.js
+++ b/blocks/hero/index.js
@@ -125,11 +125,6 @@ export default registerBlockType(
 			const ampValueProp = {
 				'[value]': 'fields_query'
 			};
-
-			const ampSrcProp = {
-				'data-ampsrc': "'" + travelGlobals.apiUrl + "wp/v2/adventures?search=' + fields_query_live"
-			};
-
 			const departureClassNameProp = {
 				'[class]': "'travel-date-input relative bold flex-auto' + (fields_start ? ' travel-date-input-touched' : '')"
 			};
@@ -158,25 +153,6 @@ export default registerBlockType(
 										});' value='' { ...ampValueProp } />
 										<svg className='travel-icon' viewBox='0 0 74 100'><path fill='currentColor' d='M40.18 95.404A3.944 3.944 0 0 1 37 97a3.944 3.944 0 0 1-3.18-1.596C28.268 87.787 5 54.66 5 34.334 5 17.027 19.327 3 37 3c17.673 0 32 14.028 32 31.333 0 20.327-23.267 53.454-28.82 61.07zM37 14.75c-11.046 0-20 8.768-20 19.583 0 10.816 8.954 19.584 20 19.584s20-8.768 20-19.584c0-5.193-2.107-10.174-5.858-13.847-3.75-3.672-8.838-5.736-14.142-5.736z'></path></svg>
 									</label>
-
-									<amp-list layout='fixed-height' height="1px" src={ travelGlobals.apiUrl + 'wp/v2/adventures' } {...ampSrcProp } aria-live='polite'>
-										<template type='amp-mustache'>
-											{ wp.element.createElement(
-												'datalist',
-												{
-													id: 'locations'
-												},
-												'{{#adventures}}',
-												wp.element.createElement(
-													'option',
-													{
-														value: '{{title.rendered}}'
-													},
-													'{{/adventures}}'
-												)
-											) }
-										</template>
-									</amp-list>
 
 								<div className='travel-hero-search-dates flex my2 justify-around'>
 									<label className='travel-date-input relative bold flex-auto' { ...departureClassNameProp } >

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -376,6 +376,9 @@ function amp_travel_states() {
 
 			<amp-state id="fields_start"><script type="application/json"><?php echo isset( $_GET['start'] ) ? sprintf( '"%s"', esc_html( $_GET['start'] ) ) : '""'; ?></script></amp-state>
 			<amp-state id="fields_end"><script type="application/json"><?php echo isset( $_GET['end'] ) ? sprintf( '"%s"', esc_html( $_GET['end'] ) ) : '""'; ?></script></amp-state>
+		<?php else : ?>
+			<amp-state id="fields_start"><script type="application/json">""</script></amp-state>
+			<amp-state id="fields_end"><script type="application/json">""</script></amp-state>
 		<?php endif; ?>
 	<?php
 	endif;


### PR DESCRIPTION
@ThierryA 
This removes the `amp-list` template for the hero block to remove the errors for now.

Fixes #77 